### PR TITLE
Fixing breaking prod issues w/ client hardcoded IP and client dockerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Building a web application around JoJoGAN face stylization.
 cd /server
 npm install
 ```
-- Create .env and add PORT=8080 as well as AWS credentials (region, access key, and access key id)
+- Create .env and add:
 ```
 PORT=8080
 REGION="region"
@@ -18,8 +18,12 @@ AWS_ACCESS_KEY_ID="access-key-id"
 
 ```
 cd /client
+npm install
 ```
-Create .env.local and add NEXT_PUBLIC_SERVER_URL="http://localhost:8080"
+- Create .env and add:
+```
+NEXT_PUBLIC_IP = "<IP address of server>"
+```
 
 ## 3) Start Server and Client
 ```

--- a/client/Api/UsersApi.jsx
+++ b/client/Api/UsersApi.jsx
@@ -1,9 +1,9 @@
 import axios from "axios";
 
 const API_URL =
-  process.env.NODE_ENV === "production"
-    ? "http://18.116.241.33:8080/users/"
-    : "http://18.116.241.33:8080/users/";
+  process.env.NODE_ENV === "production" 
+    ? `http://${process.env.NEXT_PUBLIC_IP}:8080/users/`
+    : "http://localhost:8080/users/";
 
 const UsersApi = axios.create({
   baseURL: API_URL,

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # Create image based on the official Node image from dockerhub
-FROM node:18-alpine
+FROM --platform=linux/amd64 node:18.17-alpine
 
 # Copying src 
 COPY . /client/

--- a/client/components/profile.jsx
+++ b/client/components/profile.jsx
@@ -35,7 +35,7 @@ function Profile() {
       <Modal toggle={() => setModalOpen(!modalOpen)} isOpen={modalOpen}>
         <div className="text-center mt-3 m-2">
           <h5 className="text-gray-600 font-bold">
-            {username}'s Profile
+            {username}&apos;s Profile
           </h5>
         </div>
         <ModalBody>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
 
   frontend:
     image: facestylizer/frontend
+    platform: linux/amd64
     build: ./client
     ports:
       - 3000:3000


### PR DESCRIPTION
Changes:

1) `client/Dockerfile` & `docker-compose.yml` 
- We had issues dockerizing the frontend container in production as the service just hangs on npm install packages. I switched the Docker image to a more compatible version from this [github issue](https://github.com/nodejs/docker-node/issues/1946#issuecomment-1734363494).
- Also changed to build the frontend container on a linux platform

2) `client/Api/UsersApi.jsx`
- Whenever we changed the IP of the server (for a reboot or some other problems), the previous hardcoded IP would break login and signup functionality.
- Changed it to take the IP from a variable in .env

3) `README.md`
- Documented where to include .env and IP address for the above change to work. 

4) `client/components/profile.jsx`
- Had a problem w/ `npm run build` with the escape character for "{username}'s profile". Small change to fix issue.

Demo:
After adding the IP in client/.env. Using Jubayer's example profile that currently lives in the production DB. 

a) ```npm run build && npm run start``` - Starts the frontend on production so logins and signup hit the production DB
<img width="1673" alt="image" src="https://github.com/csci-499-sp24/FaceStylizer/assets/38477812/55c79c49-ffd8-4c64-88f5-589ee6e617d3">

b) ```npm run build && npm run dev``` - Starts the frontend on development so logins and signup hit the local DB.
<img width="1683" alt="image" src="https://github.com/csci-499-sp24/FaceStylizer/assets/38477812/ea24cc34-ac6f-41bb-bf43-1544cb4a0868">
