### PR TITLE
Fixes image upload to S3 due to client hardcoded IP

### DIFF
--- a/client/Api/FilesApi.jsx
+++ b/client/Api/FilesApi.jsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const FILE_API_URL =
     process.env.NODE_ENV === "production"
-        ? "http://localhost:8080/files/"
+        ? `http://${process.env.NEXT_PUBLIC_IP}:8080/files/`
         : "http://localhost:8080/files/";
 
 const FilesApi = axios.create({

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -16,5 +16,7 @@ RUN npm install
 # Expose the port the app runs in
 EXPOSE 3000
  
+RUN npm run build
+
 # Serve the app
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "start"]

--- a/client/components/MlUi.jsx
+++ b/client/components/MlUi.jsx
@@ -137,6 +137,8 @@ function MlUi({ images, onBack }) {
                         const url = 'upload/' + sessionStorage.getItem('username');
                         console.log(url);
 
+                        console.log(process.env.NODE_ENV);       
+                        console.log(`http://${process.env.NEXT_PUBLIC_IP}:8080/files/`);       
                         let formData = new FormData();
                         if (selectedImage) {
                             // Convert data URL to blob
@@ -152,8 +154,10 @@ function MlUi({ images, onBack }) {
                                 }
                             });
                             console.log('Uploaded file successfully:', response.data);
+                            console.log(FilesApi.getUri);
                         } catch (error) {
                             console.error('Error uploading file:', error);
+                            console.log(FilesApi.getUri);
                         }
                     }}
                     disabled={!selectedImage || !selectedStyle} // Button is disabled if no image is selected or no style is chosen

--- a/client/components/MlUi.jsx
+++ b/client/components/MlUi.jsx
@@ -138,7 +138,6 @@ function MlUi({ images, onBack }) {
                         console.log(url);
 
                         console.log(process.env.NODE_ENV);       
-                        console.log(`http://${process.env.NEXT_PUBLIC_IP}:8080/files/`);       
                         let formData = new FormData();
                         if (selectedImage) {
                             // Convert data URL to blob
@@ -154,10 +153,8 @@ function MlUi({ images, onBack }) {
                                 }
                             });
                             console.log('Uploaded file successfully:', response.data);
-                            console.log(FilesApi.getUri);
                         } catch (error) {
                             console.error('Error uploading file:', error);
-                            console.log(FilesApi.getUri);
                         }
                     }}
                     disabled={!selectedImage || !selectedStyle} // Button is disabled if no image is selected or no style is chosen


### PR DESCRIPTION
Changes:
1. `client/Dockerfile` and `client/Api/FilesApi.jsx`
- client was started in dev mode due to `CMD ["npm", "run", "dev"]` causing interaction with the incorrect backend (localhost:8080 vs <server IP>:8080)
- specified url based on environment condition: FilesAPI now takes the IP or localhost depending on the environment

2. `client/components/MlUi.jsx`
- minor addition printing the current environment before uploading images