### PR TITLE
changes base stylizer endpoint url and port

### DIFF
--- a/client/Api/StylizerApi.jsx
+++ b/client/Api/StylizerApi.jsx
@@ -2,8 +2,8 @@ import axios from "axios";
 
 const STYLIZER_CLOUD_RUN_ENDPOINT_URL = 
     process.env.NODE_ENV === "production"
-        ? `${process.env.NEXT_PUBLIC_STYLIZER_URL}`
-        : "http://localhost:8080/";
+        ? `http://${process.env.NEXT_PUBLIC_IP}:8090/`
+        : "http://localhost:8090/";
 
 const StylizerApi = axios.create({
     baseURL: STYLIZER_CLOUD_RUN_ENDPOINT_URL,

--- a/stylizer/Dockerfile
+++ b/stylizer/Dockerfile
@@ -15,7 +15,7 @@ ENV PYTHONUNBUFFERED True
 COPY . ./
 
 # Expose PORT
-ENV PORT 8080
+ENV PORT 8090
 
 # Install Dependencies
 RUN pip install --no-cache-dir -r requirements.txt
@@ -24,5 +24,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN cd dlib && mkdir build && cd build && cmake ../ && cmake --build . && cd .. && python3 setup.py install
 
 # Start handler
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind $PORT --workers 1 --threads 8 --timeout 0 main:app
 

--- a/stylizer/main.py
+++ b/stylizer/main.py
@@ -50,4 +50,4 @@ def home():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8090)))


### PR DESCRIPTION
Changes:
`client/Api/StylizerApi.jsx` - Changes base API endpoint url of stylizer web server, deprecating GCP function
`/stylizer` - Changes the base port so backend and stylizer don't conflict on port 8080.